### PR TITLE
Add logging to the container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "slim/slim": "^3.12",
         "mos/cdatabase": "^0.1.1",
         "robmorgan/phinx": "^0.10.6",
-        "slim/twig-view": "^2.4"
+        "slim/twig-view": "^2.4",
+        "monolog/monolog": "^1.24"
     },
     "require-dev": {
         "pds/skeleton": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5cc130807804020ea7601e041b324fb",
+    "content-hash": "5d2af41e8714d388dd47b8249d6ca64d",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -371,6 +371,84 @@
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
             "homepage": "https://github.com/container-interop/container-interop",
             "time": "2017-02-14T19:40:03+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
+                "reference": "bfc9ebb28f97e7a24c45bdc3f0ff482e47bb0266",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "jakub-onderka/php-parallel-lint": "0.9",
+                "php-amqplib/php-amqplib": "~2.4",
+                "php-console/php-console": "^3.1.3",
+                "phpunit/phpunit": "~4.5",
+                "phpunit/phpunit-mock-objects": "2.3.0",
+                "ruflin/elastica": ">=0.90 <3.0",
+                "sentry/sentry": "^0.13",
+                "swiftmailer/swiftmailer": "^5.3|^6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server via PHP Driver",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "php-console/php-console": "Allow sending log messages to Google Chrome",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "sentry/sentry": "Allow sending log messages to a Sentry server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2018-11-05T09:00:11+00:00"
         },
         {
             "name": "mos/cdatabase",

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,3 @@
+# This file's purpose is to make sure the log folder is added to the repo but the log files are not
+!.gitignore
+*

--- a/public/index.php
+++ b/public/index.php
@@ -27,6 +27,14 @@ $container['view'] = function ($container) {
     return $view;
 };
 
+$container['logger'] = function ($c) {
+    $logger = new \Monolog\Logger('startplats');
+    $file_handler = new \Monolog\Handler\StreamHandler('../logs/app.log');
+    $logger->pushHandler($file_handler);
+    return $logger;
+};
+
+
 // Register routes
 require __DIR__ . '/../src/routes.php';
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -4,6 +4,7 @@ use Slim\Http\Response;
 
 $app->get('/{name}', function (Request $req, Response $res, $args = []) {
     $name = $args['name'];
+    $this->logger->addInfo('Hello ' . $name);
     return $this->view->render($res, 'hello.html.twig', [
         'name' => $args['name']
     ]);

--- a/tests/functional/BaseTestCase.php
+++ b/tests/functional/BaseTestCase.php
@@ -50,6 +50,14 @@ class BaseTestCase extends \PHPUnit\Framework\TestCase // https://github.com/sym
         $app = new App();
 
         $container = $app->getContainer();
+        $container['db'] = function ($c) {
+            $conf = $c['settings']['db'];
+            $db = new Database(['dsn' => 'mysql:host=' . $conf['host'] . ';dbname=' . $conf['dbname'],
+                'username' => $conf['user'], 'password' => $conf['pass']]);
+            $db->connect();
+            return $db;
+        };
+
         $container['view'] = function ($container) {
             $view = new \Slim\Views\Twig(__DIR__ . '/../../resources/views/', [
                 'cache' => false
@@ -58,6 +66,13 @@ class BaseTestCase extends \PHPUnit\Framework\TestCase // https://github.com/sym
             $uri = \Slim\Http\Uri::createFromEnvironment(new \Slim\Http\Environment($_SERVER));
             $view->addExtension(new \Slim\Views\TwigExtension($router, $uri));
             return $view;
+        };
+
+        $container['logger'] = function ($c) {
+            $logger = new \Monolog\Logger('functional_test');
+            $file_handler = new \Monolog\Handler\StreamHandler('logs/app.log');
+            $logger->pushHandler($file_handler);
+            return $logger;
         };
 
         // Register routes


### PR DESCRIPTION
/logs/ has 777 permission bits
/logs/app.log is created by Monolog and user is set by the user who first runs it. If it is first run by the test-suite it will have user who ran the test as the owner. If it is run ny apache, it will have www-data as user. One user can't append to another user's file unless the user permission is changed for the log files. Shouldn't be a problem in production or test server.